### PR TITLE
Update RcppArmadillo initialization

### DIFF
--- a/src/get_latents.cpp
+++ b/src/get_latents.cpp
@@ -40,9 +40,8 @@ arma::mat get_latents_cpp( arma::mat Y,
   unsigned int cat_Yij;
   
   // possible variable classes that are allowed
-  arma::vec var_type_all;
-  var_type_all << 1 << 2 << 3 << arma::endr;
-  
+  arma::vec var_type_all({1, 2, 3});
+    
   // checking input consistency
   if( var_type.n_rows != p ) {
     throw std::range_error("The number of columns in Y have to be equal to the lenght of vector var_type");


### PR DESCRIPTION
This one-line change updates RcppArmadillo from the now deprecated `<<` initialization to brace initialization allowed since C++11 and long been minimal standard with R too.  It would be great if you could merge this, and release and updated package "in the next little while" -- see the two prior emails I sent, and the transition log at https://github.com/RcppCore/RcppArmadillo/issues/391